### PR TITLE
Apply upstream fixes

### DIFF
--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -5824,17 +5824,6 @@ mdb_env_close0(MDB_env *env, int excl)
 			if (excl > 0)
 				semctl(env->me_rmutex->semid, 0, IPC_RMID);
 		}
-#elif defined(MDB_ROBUST_SUPPORTED)
-		/* If we have the filelock:  If we are the
-		 * only remaining user, clean up robust
-		 * mutexes.
-		 */
-		if (excl == 0)
-			mdb_env_excl_lock(env, &excl);
-		if (excl > 0) {
-			pthread_mutex_destroy(env->me_txns->mti_rmutex);
-			pthread_mutex_destroy(env->me_txns->mti_wmutex);
-		}
 #endif
 		munmap((void *)env->me_txns, (env->me_maxreaders-1)*sizeof(MDB_reader)+sizeof(MDB_txninfo));
 	}

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -7946,7 +7946,7 @@ current:
 						 * Copy end of page, adjusting alignment so
 						 * compiler may copy words instead of bytes.
 						 */
-						off = (PAGEHDRSZ + data->mv_size) & -sizeof(size_t);
+						off = (PAGEHDRSZ + data->mv_size) & -(int)sizeof(size_t);
 						memcpy((size_t *)((char *)np + off),
 							(size_t *)((char *)omp + off), sz - off);
 						sz = PAGEHDRSZ;

--- a/libraries/liblmdb/mdb.c
+++ b/libraries/liblmdb/mdb.c
@@ -7974,11 +7974,14 @@ current:
 			else if (!(mc->mc_flags & C_SUB))
 				memcpy(olddata.mv_data, data->mv_data, data->mv_size);
 			else {
+				if (key->mv_size != NODEKSZ(leaf))
+					goto new_ksize;
 				memcpy(NODEKEY(leaf), key->mv_data, key->mv_size);
 				goto fix_parent;
 			}
 			return MDB_SUCCESS;
 		}
+new_ksize:
 		mdb_node_del(mc, 0);
 	}
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes ITS#10095, ITS#8447, ITS#9961

## What does this PR do?

Keep up-to-date with upstream LMDB source code.

I recently encountered the bug: **ITS#8447** fix `cursor_put(MDB_CURRENT)` on `DUPSORT` DB with different-sized data.

The new data item content(value) is interleaved with its previous data, which causes the new value corrupted.
(New value len is shorter than old value len)

See full thread:
https://www.openldap.org/lists/openldap-bugs/201606/msg00049.html
https://www.openldap.org/lists/openldap-bugs/201606/msg00050.html
https://www.openldap.org/lists/openldap-bugs/201606/msg00053.html